### PR TITLE
Startup link working directory fix

### DIFF
--- a/DuckDNS/ShellLink.cs
+++ b/DuckDNS/ShellLink.cs
@@ -17,6 +17,7 @@ namespace DuckDNS
             // setup shortcut information
             link.SetDescription(description);
             link.SetPath(path);
+            link.SetWorkingDirectory(Path.GetDirectoryName(path));
 
             // save it
             IPersistFile file = (IPersistFile)link;


### PR DESCRIPTION
Fixes the created startup link, to include a working directory, to read the saved "DuckDNS.cfg"