### PR TITLE
Removing invalid ipv4 and ipv6 options if you are not using the advanced IP options

### DIFF
--- a/DuckDNS/DDns.cs
+++ b/DuckDNS/DDns.cs
@@ -115,8 +115,24 @@ namespace DuckDNS
             string url = ServiceURL;
             url = url.Replace("<DOM>", domain);
             url = url.Replace("<TKN>", token);
-            url = url.Replace("<IP4>", ipv4);
-            url = url.Replace("<IP6>", ipv6);
+
+            if (ipv4 == string.Empty)
+            {
+                url = url.Replace("&ip=<IP4>", "");
+
+            }
+            else
+            {
+                url = url.Replace("<IP4>", ipv4);
+            }
+            if (ipv6 == string.Empty)
+            {
+                url = url.Replace("&ipv6=<IP6>", "");
+            }
+            else
+            {
+                url = url.Replace("<IP6>", ipv6);
+            }
             return url;
         }
 


### PR DESCRIPTION
When you are not setting the IPV4 or IPV6 the string was being parsed with empty strings, and the empty http parameters were causing the request to fail from duckdns.org.

I removed the empty parameters if they are empty strings being passed.